### PR TITLE
Removed Dawn and Shannon from Players as per Roll Call (Issue #34)

### DIFF
--- a/Roles/Player/README.md
+++ b/Roles/Player/README.md
@@ -21,6 +21,4 @@
 
 * [@macterra](https://macterra.github.io/macterra-space/)
 * [@flaxscrip](https://flaxscrip.github.io/flaxscrip-space/)
-* [@dawnTestCode](https://dawntestcode.github.io/dawnTestCode-space//)
-* [@genecyber](https://genecyber.github.io/ShannonCodePlayer-space/)
 * [@angelabacca](https://angelabacca.github.io/angela-player-space/)


### PR DESCRIPTION
Thank you both for your contributions last year. I am removing as per the Roll Call (Issue #34 )
You are welcome to join the team back as we prepare to launch the Metatron project.